### PR TITLE
feat(managers/repo): download manifest specified files

### DIFF
--- a/extractors/tar.lua
+++ b/extractors/tar.lua
@@ -1,0 +1,23 @@
+local core = require 'core'
+local util = require 'plugins.miq.util'
+local Promise = require 'plugins.miq.promise'
+
+local M = {}
+
+function M.extract(file, cwd)
+	local dir = cwd or util.dir(file)
+	system.mkdir(dir)
+
+	local promise = Promise:new()
+	core.add_thread(function()
+		local out, exitCode = util.exec {'tar', 'xvf' .. (util.ext(file) == 'gz' and 'z' or ''), file, '-C', dir}
+		if exitCode ~= 0 then
+			return promise:reject(out)
+		end
+
+		return promise:resolve()
+	end)
+	return promise
+end
+
+return M

--- a/request/curl.lua
+++ b/request/curl.lua
@@ -1,0 +1,49 @@
+local core = require 'core'
+local common = require 'core.common'
+local util = require 'plugins.miq.util'
+local Promise = require 'plugins.miq.promise'
+
+local M = {}
+
+function M.req(url)
+	local promise = Promise:new()
+
+	core.add_thread(function()
+		local out = util.exec {'curl', '--fail', '-s', url}
+		if not out then promise:reject() end
+
+		if out.exitCode ~= 0 then
+			promise:reject {
+				success = false,
+				out = out
+			}
+			return
+		end
+
+		promise:resolve {
+			success = true,
+			out = out
+		}
+	end)
+	return promise
+end
+
+function M.download(url, dest)
+	local destDir = util.dir(dest)
+	local fname = common.basename(dest)
+
+	local promise = Promise:new()
+	core.add_thread(function()
+		local out, exitCode = util.exec {'curl', '-L', '--create-dirs', '--output-dir', destDir, '--fail', url, '-o', fname}
+		if not out then promise:reject() end
+
+		if exitCode ~= 0 then
+			return promise:reject(out)
+		else
+			return promise:resolve(out)
+		end
+	end)
+	return promise
+end
+
+return M

--- a/util.lua
+++ b/util.lua
@@ -73,4 +73,24 @@ function M.join(parts)
 	return str
 end
 
+function M.contains(tbl, match)
+	for _, v in ipairs(tbl) do
+		if v == match then return true end
+	end
+
+	return false
+end
+
+function M.ext(path)
+	return path:match '^.+%.(.+)$'
+end
+
+function M.cleanPath(path)
+	return path:gsub(string.format('%s$', '%' .. PATHSEP), '')
+end
+
+function M.dir(path)
+	return M.cleanPath(path):match('(.*[/\\])')
+end
+
 return M


### PR DESCRIPTION
resolves #10 

makes it possible to install plugins that need additional files (like terminal and lsp servers) with miq

- [x] Extract tar
- [ ] Extract zip
- [ ] Use manifest specified path
- [ ] Check `optional`?
- [ ] Check `checksum`?